### PR TITLE
Fix syntax error in Python 3: u'' -> ''. Also add .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.pyc
+__pycache__
+*~
+.DS_Store
+build/*
+

--- a/pydot/__init__.py
+++ b/pydot/__init__.py
@@ -295,7 +295,7 @@ def graph_from_edges(edge_list, node_prefix='', directed=False):
     return graph
 
 
-def graph_from_adjacency_matrix(matrix, node_prefix=u'', directed=False):
+def graph_from_adjacency_matrix(matrix, node_prefix='', directed=False):
     """Creates a basic graph out of an adjacency matrix.
 
     The matrix has to be a list of rows of values


### PR DESCRIPTION
I wasn't able to install this version of pydot with Python 3.2 due to a syntax error. Here's a quick and simple fix.
