### PR TITLE
Fixes syntax error in older versions of graphviz.

### DIFF
--- a/pydot/__init__.py
+++ b/pydot/__init__.py
@@ -257,6 +257,10 @@ def needs_quotes(s):
 
 
 def quote_if_necessary(s):
+    # Older versions of graphviz throws a syntax error for empty values without
+    # quotes, e.g. [label=]
+    if s == '':
+        return '""'
 
     if isinstance(s, bool):
         if s is True:


### PR DESCRIPTION
Older versions of graphviz (tested on version 2.26.3 (20100126.1600)) complains when an attribute is empty without quotes. `[label=]` fails but `[label=""]` works, so the `quote_if_necessary` function has been updated to accommodate this.
