### PR TITLE
Integration with Jupyter notebook

### DIFF
--- a/pydot/__init__.py
+++ b/pydot/__init__.py
@@ -836,6 +836,7 @@ class Node(Common):
             styles.append(style)
 
         self.obj_dict['attributes']['style'] = ','.join(styles)
+        return self
 
     def to_string(self):
         """Returns a string representation of the node in dot language.
@@ -1257,6 +1258,7 @@ class Graph(Common):
             self.obj_dict['nodes'][graph_node.get_name()].append(graph_node.obj_dict)
 
         graph_node.set_sequence(self.get_next_sequence_number())
+        return self
 
     def del_node(self, name, index=None):
         """Delete a node from the graph.
@@ -1355,6 +1357,7 @@ class Graph(Common):
 
         graph_edge.set_sequence(self.get_next_sequence_number())
         graph_edge.set_parent_graph(self.get_parent_graph())
+        return self
 
     def del_edge(self, src_or_list, dst=None, index=None):
         """Delete an edge from the graph.
@@ -1474,6 +1477,7 @@ class Graph(Common):
         sgraph.set_sequence(self.get_next_sequence_number())
 
         sgraph.set_parent_graph(self.get_parent_graph())
+        return self
 
     def get_subgraph(self, name):
         """Retrieved a subgraph from the graph.
@@ -1757,6 +1761,9 @@ class Dot(Graph):
 
     def __setstate__(self, state):
         self.obj_dict = state
+
+    def _repr_png_(self):
+        return self.create_png()
 
     def set_shape_files(self, file_paths):
         """Add the paths of the required image files.


### PR DESCRIPTION
This PR allows using pydot inside a Jupyter notebook as it automatically displays graphs as images - see [example notebook](http://nbviewer.ipython.org/github/yoavram/ipython-notebooks/blob/master/pydot_example.ipynb).

Changes:
- Added a `_repr_png` as expected by Jupyter notebook
- Return `self` from some methods to induce repr in the notebook

Tested the above notebook on Jupyter 4.0.6 with Python **2.7.10** and **3.4.3** on Windows 7 with Graphviz 2.34.
I didn't change `ChangLog` or `setup.py`.
I ran the testsuite using `cd tests; python pydot_unittest.py`, got the same results as I got from the master branch, that is (only errors are shown):

```
======================================================================
ERROR: test_graph_with_shapefiles (__main__.TestGraphAPI)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "pydot_unittest.py", line 158, in test_graph_with_shapefiles
  File "d:\workspace\pydot-1\pydot\__init__.py", line 1968, in create
    status, stderr_output))
pydot.InvocationException: Program terminated with status: 3221225477. stderr follows: []

======================================================================
FAIL: test_graphviz_regression_tests (__main__.TestGraphAPI)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "pydot_unittest.py", line 223, in test_graphviz_regression_tests
    def test_graphviz_regression_tests(self):
  File "pydot_unittest.py", line 250, in _render_and_compare_dot_files
AssertionError: 'c2d16f775630039904d3da975941a5e6c16e870357a119488023cc96dce2a451' != '7df8d46b62681fa1f73bf313e46c81c634fd1100e0904b35a3d5106dab8fa9a3'
- c2d16f775630039904d3da975941a5e6c16e870357a119488023cc96dce2a451
+ 7df8d46b62681fa1f73bf313e46c81c634fd1100e0904b35a3d5106dab8fa9a3
----------------------------------------------------------------------
```
